### PR TITLE
Sign files

### DIFF
--- a/sros2/setup.py
+++ b/sros2/setup.py
@@ -68,6 +68,7 @@ enhance the security of ROS 2 deployments.""",
             'generate_artifacts = sros2.verb.generate_artifacts:GenerateArtifactsVerb',
             'generate_policy = sros2.verb.generate_policy:GeneratePolicyVerb',
             'list_keys = sros2.verb.list_keys:ListKeysVerb',
+            'sign_policy = sros2.verb.sign_policy:SignPolicyVerb',
         ],
     },
     package_data={

--- a/sros2/setup.py
+++ b/sros2/setup.py
@@ -69,6 +69,7 @@ enhance the security of ROS 2 deployments.""",
             'generate_policy = sros2.verb.generate_policy:GeneratePolicyVerb',
             'list_keys = sros2.verb.list_keys:ListKeysVerb',
             'sign_policy = sros2.verb.sign_policy:SignPolicyVerb',
+            'sign_permissions = sros2.verb.sign_permissions:SignPermissionsVerb',
         ],
     },
     package_data={

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -178,6 +178,15 @@ def create_keystore(keystore_path):
     print('cheers!')
     return True
 
+def sign_keystore_policy(keystore_path):
+    ca_key_path = os.path.join(keystore_path, 'ca.key.pem')
+    ca_cert_path = os.path.join(keystore_path, 'ca.cert.pem')
+    gov_path = os.path.join(keystore_path, 'governance.xml')
+    signed_gov_path = os.path.join(keystore_path, 'governance.p7s')
+    print('creating signed governance file: %s' % signed_gov_path)
+    _create_smime_signed_file(ca_cert_path, ca_key_path, gov_path, signed_gov_path)
+    
+
 
 def is_valid_keystore(path):
     return (

--- a/sros2/sros2/api/__init__.py
+++ b/sros2/sros2/api/__init__.py
@@ -186,6 +186,14 @@ def sign_keystore_policy(keystore_path):
     print('creating signed governance file: %s' % signed_gov_path)
     _create_smime_signed_file(ca_cert_path, ca_key_path, gov_path, signed_gov_path)
     
+def sign_permission_file (keystore_path, key_dir):
+    permissions_path = os.path.join(keystore_path, key_dir, 'permissions.xml')
+    signed_permissions_path = os.path.join(keystore_path, key_dir, 'permissions.p7s')
+    keystore_ca_key_path = os.path.join(keystore_path, 'ca.key.pem')
+    keystore_ca_cert_path = os.path.join(keystore_path, 'ca.cert.pem')
+    _create_smime_signed_file(
+        keystore_ca_cert_path, keystore_ca_key_path, permissions_path, signed_permissions_path)
+
 
 
 def is_valid_keystore(path):

--- a/sros2/sros2/verb/sign_permissions.py
+++ b/sros2/sros2/verb/sign_permissions.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sros2.api import sign_keystore_policy
+from sros2.api import sign_permission_file
 from sros2.verb import VerbExtension
 
 
-class SignPolicyVerb(VerbExtension):
-    """Sign the domain governance xml file."""
+class SignPermissionsVerb(VerbExtension):
+    """Sign the node permissions xml file."""
 
     def add_arguments(self, parser, cli_name):
         arg = parser.add_argument('ROOT', help='root path of keystore')
+        parser.add_argument('NAME', help='key name, aka ROS node name')
 
     def main(self, *, args):
-        success = sign_keystore_policy(args.ROOT)
+        success = sign_permission_file(args.ROOT, args.NAME)
         return 0 if success else 1

--- a/sros2/sros2/verb/sign_policy.py
+++ b/sros2/sros2/verb/sign_policy.py
@@ -1,0 +1,27 @@
+# Copyright 2016-2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sros2.api import sign_keystore_policy
+from sros2.verb import VerbExtension
+
+
+class SignPolicyVerb(VerbExtension):
+    """Create key."""
+
+    def add_arguments(self, parser, cli_name):
+        arg = parser.add_argument('ROOT', help='root path of keystore')
+
+    def main(self, *, args):
+        success = sign_keystore_policy(args.ROOT)
+        return 0 if success else 1


### PR DESCRIPTION
This adds two verbs to sros2 security:

ros2 security sign_policy [keystore]
ros2 security sign_permissions [keystore] [nodename]

This allows you to tweak the governance.xml and permissions.xml files in the security tree and re-sign the files. This is primarily for testing since these files will eventually be automatically generated by NoDL so they may not be worth publishing.

If we do want to move forward with this, remaining work includes at least:
- propagating updated policy files down the full security tree
- better path management (currently requires you to start in the right directory; likely a problem with the full library and not just these verbs)
- updated documentation, possibly incuding the tutorial